### PR TITLE
build: fix install path for wingpanel indicator

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -25,8 +25,10 @@ dependencies = {
     'wingpanel': wingpanel
 }
 
+libdir = join_paths(get_option('prefix'), get_option('libdir'))
+
 indicator_name = 'ayatana'
-indicator_dir  = dependencies['wingpanel'].get_pkgconfig_variable('indicatorsdir')
+indicator_dir  = dependencies['wingpanel'].get_pkgconfig_variable('indicatorsdir', define_variable: ['libdir', libdir])
 
 # ----------------------------------------------------------------------------------------------------------------------
 # Bindings:


### PR DESCRIPTION
Hi, we ~~are trying to package this~~ just packaged this for NixOS as requested in https://github.com/NixOS/nixpkgs/issues/144045.

On NixOS all packages are installed into their own immutable prefix. Because of this dependencies['wingpanel'].get_pkgconfig_variable will return a path from within wingpanel's prefix and we cannot write to it. By using define_variable we can replace the libdir to be from the paths from meson. This should have no affect on elementary OS.

Similar PR: https://github.com/pantheon-tweaks/pantheon-tweaks/pull/104, https://github.com/elementary/switchboard-plug-about/pull/100.

Thanks for reviewing this!

---

By the way it will be really nice to tag release again so we can track updates easier.